### PR TITLE
function calling

### DIFF
--- a/fc.ts
+++ b/fc.ts
@@ -30,15 +30,8 @@ async function run() {
 
         const { object } = await generateObject({
             model: openai('gpt-4o-mini'),
-            output: 'enum',
-            enum: ['calendar', 'tenis', 'unknown'],
-            // schema: z.object({
-            //     recipe: z.object({
-            //         name: z.string(),
-            //         ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
-            //         steps: z.array(z.string()),
-            //     }),
-            // }),
+            output: 'array',
+            schema: z.enum(['calendar', 'tenis', 'unknown']),
             prompt,
         });
         console.log('回答:', object);

--- a/fc.ts
+++ b/fc.ts
@@ -1,0 +1,67 @@
+// https://sdk.vercel.ai/docs/ai-sdk-core/generating-structured-data
+
+import { generateObject } from 'ai';
+import { z } from 'zod'
+import { createOpenAI } from '@ai-sdk/openai';
+import * as readline from 'readline';
+
+const openai = createOpenAI({
+    apiKey: process.env.OPENAI_KEY,
+    baseURL: process.env.OPENAI_BASEURL,
+});
+
+async function run() {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    while (true) {
+        const prompt = await new Promise<string>((resolve) => {
+            rl.question('请输入你的问题 (输入 exit 退出): ', (answer) => {
+                resolve(answer);
+            });
+        });
+
+        if (prompt.toLowerCase() === 'exit' || prompt.toLowerCase() === 'quit') {
+            rl.close();
+            break;
+        }
+
+        const { object } = await generateObject({
+            model: openai('gpt-4o-mini'),
+            output: 'enum',
+            enum: ['calendar', 'tenis', 'unknown'],
+            // schema: z.object({
+            //     recipe: z.object({
+            //         name: z.string(),
+            //         ingredients: z.array(z.object({ name: z.string(), amount: z.string() })),
+            //         steps: z.array(z.string()),
+            //     }),
+            // }),
+            prompt,
+        });
+        console.log('回答:', object);
+        console.log('-------------------');
+    }
+}
+
+run()
+
+/*
+first-agent git:(function-calling) ✗ npm start fc.ts
+
+> first-agent@1.0.0 start
+> NODE_OPTIONS='--import=tsx' node --env-file=.env fc.ts
+
+请输入你的问题 (输入 exit 退出): 明天天气如何
+回答: unknown
+-------------------
+请输入你的问题 (输入 exit 退出): 帮忙预定明天的网球课
+回答: tenis
+-------------------
+请输入你的问题 (输入 exit 退出): 创建明天的日历
+回答: calendar
+-------------------
+请输入你的问题 (输入 exit 退出): exit
+*/

--- a/fc.ts
+++ b/fc.ts
@@ -4,10 +4,15 @@ import { generateObject } from 'ai';
 import { z } from 'zod'
 import { createOpenAI } from '@ai-sdk/openai';
 import * as readline from 'readline';
+import { createOllama } from "ollama-ai-provider";
 
 const openai = createOpenAI({
     apiKey: process.env.OPENAI_KEY,
     baseURL: process.env.OPENAI_BASEURL,
+});
+
+const ollama = createOllama({
+    baseURL: "http://localhost:11434/api",
 });
 
 async function run() {
@@ -29,9 +34,10 @@ async function run() {
         }
 
         const { object } = await generateObject({
-            model: openai('gpt-4o-mini'),
+            // model: openai('gpt-4o-mini'),
+            model: ollama("qwen2.5:14b"),
             output: 'array',
-            schema: z.enum(['calendar', 'tenis', 'unknown']),
+            schema: z.enum(['calendar', 'tennis', 'unknown']),
             prompt,
         });
         console.log('回答:', object);

--- a/fc.ts
+++ b/fc.ts
@@ -1,6 +1,6 @@
 // https://sdk.vercel.ai/docs/ai-sdk-core/generating-structured-data
 
-import { generateObject } from 'ai';
+import { generateObject, extractReasoningMiddleware, wrapLanguageModel } from 'ai';
 import { z } from 'zod'
 import { createOpenAI } from '@ai-sdk/openai';
 import * as readline from 'readline';
@@ -33,8 +33,14 @@ async function run() {
             break;
         }
 
+        const model = wrapLanguageModel({
+            model: ollama("deepseek-r1:14b"),
+            middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        });
+
         const { object } = await generateObject({
             // model: openai('gpt-4o-mini'),
+            // model: model,
             model: ollama("qwen2.5:14b"),
             output: 'array',
             schema: z.enum(['calendar', 'tennis', 'unknown']),

--- a/fc.ts
+++ b/fc.ts
@@ -40,21 +40,3 @@ async function run() {
 }
 
 run()
-
-/*
-first-agent git:(function-calling) ✗ npm start fc.ts
-
-> first-agent@1.0.0 start
-> NODE_OPTIONS='--import=tsx' node --env-file=.env fc.ts
-
-请输入你的问题 (输入 exit 退出): 明天天气如何
-回答: unknown
--------------------
-请输入你的问题 (输入 exit 退出): 帮忙预定明天的网球课
-回答: tenis
--------------------
-请输入你的问题 (输入 exit 退出): 创建明天的日历
-回答: calendar
--------------------
-请输入你的问题 (输入 exit 退出): exit
-*/

--- a/package.json
+++ b/package.json
@@ -24,5 +24,10 @@
   "devDependencies": {
     "@types/node": "^22.13.1",
     "tsx": "^4.19.2"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@ai-sdk/provider-utils@2.1.2": "patches/@ai-sdk__provider-utils@2.1.2.patch"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^1.1.2",
     "@statelyai/agent": "^1.1.6",
+    "ai": "^4.1.25",
     "ollama-ai-provider": "^1.2.0",
     "xstate": "^5.19.2",
     "zod": "^3.24.1"

--- a/patches/@ai-sdk__provider-utils@2.1.2.patch
+++ b/patches/@ai-sdk__provider-utils@2.1.2.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.js b/dist/index.js
+index 968178c336377c656822b85112e8bafb3aa02402..a2b17b237b4f34a133a162b6c6950e7834b6cb56 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -582,7 +582,7 @@ var createJsonStreamResponseHandler = (chunkSchema) => async ({ response }) => {
+   };
+ };
+ var createJsonResponseHandler = (responseSchema) => async ({ response, url, requestBodyValues }) => {
+-  const responseBody = await response.text();
++  const responseBody = await response.text();console.log('^^^debug^^^', responseBody);
+   const parsedResult = safeParseJSON({
+     text: responseBody,
+     schema: responseSchema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,11 @@ settings:
 overrides:
   '@ai-sdk/provider': 1.0.6
 
+patchedDependencies:
+  '@ai-sdk/provider-utils@2.1.2':
+    hash: 4345ewzxou33gwd42vunudh27a
+    path: patches/@ai-sdk__provider-utils@2.1.2.patch
+
 importers:
 
   .:
@@ -632,7 +637,7 @@ snapshots:
   '@ai-sdk/openai@1.1.2(zod@3.24.1)':
     dependencies:
       '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.1)
+      '@ai-sdk/provider-utils': 2.1.2(patch_hash=4345ewzxou33gwd42vunudh27a)(zod@3.24.1)
       zod: 3.24.1
 
   '@ai-sdk/provider-utils@1.0.22(zod@3.24.1)':
@@ -653,7 +658,7 @@ snapshots:
     optionalDependencies:
       zod: 3.24.1
 
-  '@ai-sdk/provider-utils@2.1.2(zod@3.24.1)':
+  '@ai-sdk/provider-utils@2.1.2(patch_hash=4345ewzxou33gwd42vunudh27a)(zod@3.24.1)':
     dependencies:
       '@ai-sdk/provider': 1.0.6
       eventsource-parser: 3.0.0
@@ -1062,7 +1067,7 @@ snapshots:
   ollama-ai-provider@1.2.0(zod@3.24.1):
     dependencies:
       '@ai-sdk/provider': 1.0.6
-      '@ai-sdk/provider-utils': 2.1.2(zod@3.24.1)
+      '@ai-sdk/provider-utils': 2.1.2(patch_hash=4345ewzxou33gwd42vunudh27a)(zod@3.24.1)
       partial-json: 0.1.7
     optionalDependencies:
       zod: 3.24.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@statelyai/agent':
         specifier: ^1.1.6
         version: 1.1.6(react@19.0.0)(sswr@2.1.0(svelte@5.19.2))(svelte@5.19.2)(vue@3.5.13)(zod@3.24.1)
+      ai:
+        specifier: ^4.1.25
+        version: 4.1.25(react@19.0.0)(zod@3.24.1)
       ollama-ai-provider:
         specifier: ^1.2.0
         version: 1.2.0(zod@3.24.1)
@@ -75,12 +78,33 @@ packages:
       zod:
         optional: true
 
+  '@ai-sdk/provider-utils@2.1.6':
+    resolution: {integrity: sha512-Pfyaj0QZS22qyVn5Iz7IXcJ8nKIKlu2MeSAdKJzTwkAks7zdLaKVB+396Rqcp1bfQnxl7vaduQVMQiXUrgK8Gw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@ai-sdk/provider@1.0.6':
     resolution: {integrity: sha512-hwj/gFNxpDgEfTaYzCYoslmw01IY9kWLKl/wf8xuPvHtQIzlfXWmmUwc8PnCwxyt8cKzIuV0dfUghCf68HQ0SA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@0.0.70':
     resolution: {integrity: sha512-GnwbtjW4/4z7MleLiW+TOZC2M29eCg1tOUpuEiYFMmFNZK8mkrqM0PFZMo6UsYeUYMWqEOOcPOU9OQVJMJh7IQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      zod:
+        optional: true
+
+  '@ai-sdk/react@1.1.10':
+    resolution: {integrity: sha512-RTkEVYKq7qO6Ct3XdVTgbaCTyjX+q1HLqb+t2YvZigimzMCQbHkpZCtt2H2Fgpt1UOTqnAAlXjEAgTW3X60Y9g==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -111,6 +135,15 @@ packages:
 
   '@ai-sdk/ui-utils@0.0.50':
     resolution: {integrity: sha512-Z5QYJVW+5XpSaJ4jYCCAVG7zIAuKOOdikhgpksneNmKvx61ACFaf98pmOd+xnjahl0pIlc/QIe6O4yVaJ1sEaw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/ui-utils@1.1.10':
+    resolution: {integrity: sha512-x+A1Nfy8RTSatdCe+7nRpHAZVzPFB6H+r+2JKoapSvrwsu9mw2pAbmFgV8Zaj94TsmUdTlO0/j97e63f+yYuWg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -391,6 +424,18 @@ packages:
       zod:
         optional: true
 
+  ai@4.1.25:
+    resolution: {integrity: sha512-gBdx5QqM3EK97F9/opVicP3WMHfiR0/cc96xdNnsFLpcuPBXPtm6lcK56G6ok19+NZggnVcS+KIHzFtp0aHC+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      zod:
+        optional: true
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -617,6 +662,15 @@ snapshots:
     optionalDependencies:
       zod: 3.24.1
 
+  '@ai-sdk/provider-utils@2.1.6(zod@3.24.1)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.6
+      eventsource-parser: 3.0.0
+      nanoid: 3.3.8
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.24.1
+
   '@ai-sdk/provider@1.0.6':
     dependencies:
       json-schema: 0.4.0
@@ -625,6 +679,16 @@ snapshots:
     dependencies:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.24.1)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.24.1)
+      swr: 2.3.0(react@19.0.0)
+      throttleit: 2.1.0
+    optionalDependencies:
+      react: 19.0.0
+      zod: 3.24.1
+
+  '@ai-sdk/react@1.1.10(react@19.0.0)(zod@3.24.1)':
+    dependencies:
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
+      '@ai-sdk/ui-utils': 1.1.10(zod@3.24.1)
       swr: 2.3.0(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
@@ -654,6 +718,14 @@ snapshots:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.24.1)
       json-schema: 0.4.0
       secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.24.1(zod@3.24.1)
+    optionalDependencies:
+      zod: 3.24.1
+
+  '@ai-sdk/ui-utils@1.1.10(zod@3.24.1)':
+    dependencies:
+      '@ai-sdk/provider': 1.0.6
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
       zod-to-json-schema: 3.24.1(zod@3.24.1)
     optionalDependencies:
       zod: 3.24.1
@@ -888,6 +960,18 @@ snapshots:
     transitivePeerDependencies:
       - solid-js
       - vue
+
+  ai@4.1.25(react@19.0.0)(zod@3.24.1):
+    dependencies:
+      '@ai-sdk/provider': 1.0.6
+      '@ai-sdk/provider-utils': 2.1.6(zod@3.24.1)
+      '@ai-sdk/react': 1.1.10(react@19.0.0)(zod@3.24.1)
+      '@ai-sdk/ui-utils': 1.1.10(zod@3.24.1)
+      '@opentelemetry/api': 1.9.0
+      jsondiffpatch: 0.6.0
+    optionalDependencies:
+      react: 19.0.0
+      zod: 3.24.1
 
   aria-query@5.3.2: {}
 


### PR DESCRIPTION
update
tool call 和 structural output 是否可以认为解决同一类型场景的问题？

tool call：自然语言过来，识别出要调用 tool 的地方，中间，准备好结构化输入，工具返回结构化输出，再回到 LLM，最终输入一段自然语言
structural output：LLM 只做一件事情，就是把第一句的意图理解清楚，结构化输出，然后再增加新的节点，target input（ShellAgent 中的术语）到下一个节点

---

至于怎么实现的？先不细究，封装层数挺多。但是 vercel ai sdk 封装的很贴近真实需求。
初步在 createJsonResponseHandler 增加了打印日志

似乎 `ollama("deepseek-r1:14b")` `done:false` 可能得用 stream 来实现。todo

```json
{
  "model": "qwen2.5:14b",
  "created_at": "2025-02-08T06:48:46.669128705Z",
  "message": {
    "role": "assistant",
    "content": "{\n  \"elements\": [\"tennis\", \"calendar\", \"unknown\"]\n}"
  },
  "done_reason": "stop",
  "done": true,
  "total_duration": 16138904474,
  "load_duration": 15611098341,
  "prompt_eval_count": 113,
  "prompt_eval_duration": 87221000,
  "eval_count": 17,
  "eval_duration": 327915000
}
```

update
arary<enum>

```
npm start fc.ts                    

> first-agent@1.0.0 start
> NODE_OPTIONS='--import=tsx' node --env-file=.env fc.ts

请输入你的问题 (输入 exit 退出): 明天天气如何
回答: [ 'unknown' ]
-------------------
请输入你的问题 (输入 exit 退出): 帮忙预定明天的网球课
回答: [ 'tenis' ]
-------------------
请输入你的问题 (输入 exit 退出): 创建明天的日历
回答: [ 'calendar' ]
-------------------
请输入你的问题 (输入 exit 退出): 帮忙预定明天的网球课，并且创建明天的日历
回答: [ 'tenis', 'calendar' ]
-------------------
请输入你的问题 (输入 exit 退出): exit
```

```diff
-            output: 'enum',
-            enum: ['calendar', 'tenis', 'unknown'],
+            output: 'array',
+            schema: z.enum(['calendar', 'tenis', 'unknown']),
```

---

如果使用 enum 来做分流？

```
first-agent git:(function-calling) ✗ npm start fc.ts

> first-agent@1.0.0 start
> NODE_OPTIONS='--import=tsx' node --env-file=.env fc.ts

请输入你的问题 (输入 exit 退出): 明天天气如何
回答: unknown
-------------------
请输入你的问题 (输入 exit 退出): 帮忙预定明天的网球课
回答: tenis
-------------------
请输入你的问题 (输入 exit 退出): 创建明天的日历
回答: calendar
-------------------
请输入你的问题 (输入 exit 退出): exit
```