### PR TITLE
测试不同LLM在提取时间中的能力差异

### DIFF
--- a/fc.ts
+++ b/fc.ts
@@ -33,18 +33,27 @@ async function run() {
             break;
         }
 
+        // 不支持 function calling
         const model = wrapLanguageModel({
+            // model: ollama("deepseek-r1:14b"),
             model: ollama("deepseek-r1:14b"),
             middleware: extractReasoningMiddleware({ tagName: 'think' }),
         });
 
         const { object } = await generateObject({
-            // model: openai('gpt-4o-mini'),
+            // model: openai('gpt-4o-mini'), // 可以处理日期类
+            // model: openai('DeepSeek-R1'), // 不支持 function calling
             // model: model,
-            model: ollama("qwen2.5:14b"),
-            output: 'array',
-            schema: z.enum(['calendar', 'tennis', 'unknown']),
-            prompt,
+            model: ollama("qwen2.5-coder:32b"), // 至少 32b 模型
+            output: 'object',
+            schema: z.object({
+                actions: z.enum(['calendar', 'tennis', 'unknown']),
+                startDatetime: z
+                    .string(),
+                endDatetime: z
+                    .string()
+            }).describe(`当前时间 ${new Date().toLocaleDateString()}`),
+            prompt: prompt,
         });
         console.log('回答:', object);
         console.log('-------------------');


### PR DESCRIPTION
增强大模型的能力
1. LLM 本身的能力 e.g. 教授
2. RAG 外挂 e.g. 大学生 + 开卷考试
3. 微调 e.g. 大学生继续深造变成副教授 

这里面从时间上来说，1 或者 2。其中 2 我还是去尝试过。

从本 PR 验证的地方来说
```
后天上午还有哪些日程
```

qwen2.5-coder:32b gpt-4o-mini 可以识别正确。
qwen2.5:14b 不行。

