### PR TITLE
继续测试模型

### DIFF
--- a/fc2.ts
+++ b/fc2.ts
@@ -1,0 +1,50 @@
+// https://sdk.vercel.ai/docs/ai-sdk-core/generating-structured-data
+
+import { generateObject, extractReasoningMiddleware, wrapLanguageModel } from 'ai';
+import { z } from 'zod'
+import { createOpenAI } from '@ai-sdk/openai';
+import * as readline from 'readline';
+import { createOllama } from "ollama-ai-provider";
+
+const openai = createOpenAI({
+    apiKey: process.env.OPENAI_KEY,
+    baseURL: process.env.OPENAI_BASEURL,
+});
+
+const ollama = createOllama({
+    baseURL: "http://localhost:11434/api",
+});
+
+const schema = z.object({
+    actions: z.enum(['calendar', 'tennis', 'unknown']),
+    startDatetime: z
+        .string(),
+    endDatetime: z
+        .string()
+}).describe(`当前时间 ${new Date().toLocaleDateString()}`)
+
+const prompt = '后天上午还有哪些日程'
+
+console.log('prompt', prompt)
+
+async function run() {
+    const { object: o1 } = await generateObject({
+        model: openai('gpt-4o-mini'), // 可以处理日期类 $ 0.15 /M tokens | $ 0.6 /M tokens
+        output: 'object',
+        schema,
+        prompt,
+    });
+
+    console.log('o1', o1)
+
+    const { object: o2 } = await generateObject({
+        model: ollama("qwen2.5-coder:14b"),
+        output: 'object',
+        schema,
+        prompt,
+    });
+
+    console.log('o1', o2)
+}
+
+run()


### PR DESCRIPTION
测试时候，0210

都可以
```
prompt 后天上午还有哪些日程
gpt-4o-mini {
  actions: 'calendar',
  startDatetime: '2025-02-12T00:00:00',
  endDatetime: '2025-02-12T12:00:00'
}
[ollama](qwen2.5-coder:14b) {
  actions: 'calendar',
  startDatetime: '2025-10-12T09:00:00',
  endDatetime: '2025-10-12T12:00:00'
}
```

qwen 可以
```
prompt 大后天上午还有哪些日程
gpt-4o-mini {
  actions: 'calendar',
  startDatetime: '2025-02-12T00:00:00',
  endDatetime: '2025-02-12T12:00:00'
}
qwen2.5-coder:14b {
  actions: 'calendar',
  startDatetime: '2025-02-13T09:00:00',
  endDatetime: '2025-02-13T12:00:00'
}
```

同样，gpt 只能识别 `后天`，但是 qwen 也最多识别到 `大后天`
```
prompt 大大后天上午还有哪些日程
gpt-4o-mini {
  actions: 'calendar',
  startDatetime: '2025-02-12T00:00:00',
  endDatetime: '2025-02-12T12:00:00'
}
qwen2.5-coder:14b {
  actions: 'calendar',
  startDatetime: '2025-02-13T09:00:00',
  endDatetime: '2025-02-13T12:00:00'
}
```

都错了。
4o-mini 识别到本周五
gpt-4o 识别到了本周三，看起来就是无法识别 下 
qwen 识别到了上周六
```
prompt 下周三之前还有哪些日程
gpt-4o-mini {
  actions: 'calendar',
  startDatetime: '2025-02-10T00:00:00',
  endDatetime: '2025-02-14T23:59:59'
}
gpt-4o {
  actions: 'calendar',
  startDatetime: '2025-02-10T00:00:00',
  endDatetime: '2025-02-12T00:00:00'
}
qwen2.5-coder:14b {
  actions: 'calendar',
  startDatetime: '2025-02-08T09:00:00Z',
  endDatetime: '2025-02-08T17:00:00Z'
}
```

如果去掉 下，4o 4o-mini 都可以了，qwen 依旧不行。
```
prompt 周三之前还有哪些日程
gpt-4o-mini {
  actions: 'calendar',
  startDatetime: '2025-02-10T00:00:00',
  endDatetime: '2025-02-12T23:59:59'
}
gpt-4o {
  actions: 'calendar',
  startDatetime: '2025-02-10T00:00:00',
  endDatetime: '2025-02-12T23:59:59'
}
qwen2.5-coder:14b {
  actions: 'calendar',
  startDatetime: '2025-02-08T09:00:00Z',
  endDatetime: '2025-02-08T11:00:00Z'
}
```